### PR TITLE
Add Foxy support: use action_tutorials_interface for ros2 fibonacci msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 
-find_package(action_tutorials REQUIRED)
+find_package(action_tutorials_interfaces REQUIRED)
 find_package(control_msgs REQUIRED)
 
 # find ROS 1 packages
@@ -60,7 +60,7 @@ add_executable(action_bridge_fibonacci_1_2
 )
 ament_target_dependencies(action_bridge_fibonacci_1_2
     "ros1_roscpp" "ros1_actionlib" "ros1_actionlib_tutorials"
-    "rclcpp" "rclcpp_action" "action_tutorials"
+    "rclcpp" "rclcpp_action" "action_tutorials_interfaces"
 )
 
 add_executable(action_bridge_fibonacci_2_1
@@ -68,7 +68,7 @@ add_executable(action_bridge_fibonacci_2_1
 )
 ament_target_dependencies(action_bridge_fibonacci_2_1
     "ros1_roscpp" "ros1_actionlib" "ros1_actionlib_tutorials"
-    "rclcpp" "rclcpp_action" "action_tutorials"
+    "rclcpp" "rclcpp_action" "action_tutorials_interfaces"
 )
 
 install(TARGETS action_bridge_follow_joint_trajectory_1_2 action_bridge_follow_joint_trajectory_2_1 action_bridge_fibonacci_1_2 action_bridge_fibonacci_2_1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A package to bridge actions between ROS1 and ROS2. 
    
 **NOTE:**   
-- Currently supports forwarding goals from ROS1 (melodic) action client to ROS2 (dashing) action server
+- Currently supports forwarding goals from ROS1 (noetic) action client to ROS2 (foxy) action server
 - As an example, implemented interfaces for the action bridge for FibonacciAction   
   and FollowJointTrajectoryAction  
 
@@ -10,20 +10,20 @@ A package to bridge actions between ROS1 and ROS2.
 (*rosdep does not work properly with mixed ROS1 and ROS2 dependencies*)
 
 ```
-sudo apt install ros-melodic-actionlib ros-melodic-actionlib-tutorials ros-melodic-control-msgs ros-melodic-roscpp ros-dashing-control-msgs ros-dashing-rclcpp ros-dashing-rclcpp-action ros-dashing-action-tutorials
+sudo apt install ros-noetic-actionlib ros-noetic-actionlib-tutorials ros-noetic-control-msgs ros-noetic-roscpp ros-foxy-control-msgs ros-foxy-rclcpp ros-foxy-rclcpp-action ros-foxy-action-tutorials-interfaces
 ```
 
 **How to build:**  
   
 Clone the repository in the `src` folder of your ROS2 workspace.
 ```
-git clone git@github.com:ipa-hsd/action_bridge.git -b dashing-devel
+git clone git@github.com:ipa-hsd/action_bridge.git -b foxy-devel
 ```
 
 Since `action_bridge` package depends on both ROS1 and ROS2, source both workspaces.
 ```
-source /opt/ros/melodic/local_setup.bash
-source /opt/ros/dashing/local_setup.bash
+source /opt/ros/noetic/local_setup.bash
+source /opt/ros/foxy/local_setup.bash
 colcon build
 ```
 Now you are ready to run the `action_bridge`!  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 A package to bridge actions between ROS1 and ROS2. 
-   
+
 **NOTE:**   
 - Currently supports forwarding goals from ROS1 (noetic) action client to ROS2 (foxy) action server
 - As an example, implemented interfaces for the action bridge for FibonacciAction   
@@ -14,7 +14,7 @@ sudo apt install ros-noetic-actionlib ros-noetic-actionlib-tutorials ros-noetic-
 ```
 
 **How to build:**  
-  
+
 Clone the repository in the `src` folder of your ROS2 workspace.
 ```
 git clone git@github.com:ipa-hsd/action_bridge.git -b foxy-devel

--- a/src/action_bridge_fibonacci_1_2.cpp
+++ b/src/action_bridge_fibonacci_1_2.cpp
@@ -24,10 +24,10 @@
 #endif
 
 // include ROS 2
-#include <action_tutorials/action/fibonacci.hpp>
+#include <action_tutorials_interfaces/action/fibonacci.hpp>
 
 using FibonacciActionBridge = ActionBridge_1_2<actionlib_tutorials::FibonacciAction,
-                                               action_tutorials::action::Fibonacci>;
+                                               action_tutorials_interfaces::action::Fibonacci>;
 
 template <>
 void FibonacciActionBridge::translate_goal_1_to_2(const ROS1Goal &goal1, ROS2Goal &goal2)

--- a/src/action_bridge_fibonacci_2_1.cpp
+++ b/src/action_bridge_fibonacci_2_1.cpp
@@ -24,10 +24,10 @@
 #endif
 
 // include ROS 2
-#include <action_tutorials/action/fibonacci.hpp>
+#include <action_tutorials_interfaces/action/fibonacci.hpp>
 
 using FibonacciActionBridge = ActionBridge_2_1<actionlib_tutorials::FibonacciAction,
-                                               action_tutorials::action::Fibonacci>;
+                                               action_tutorials_interfaces::action::Fibonacci>;
 
 template <>
 void FibonacciActionBridge::translate_goal_2_to_1(const ROS2Goal &goal2, ROS1Goal &goal1)


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

Fibonacci action for Foxy is now released under action_tutorial_interface. Maybe merge this into a different branch instead?

For more info: https://github.com/ros2/demos/pull/378